### PR TITLE
Add userinfo key to force `DateTime` to encode in given time zone

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,10 +120,10 @@ let dateTime = DateTime(Date())
 
 // Create an encoder that will use the local timezone
 let encoder = JSONEncoder()
-encoder.userInfo[DateTime.encodingTimeZoneKey] = TimeZone.current
+encoder.userInfo[DateTime.timeZoneOverrideKey] = TimeZone.current
 
 // Or specify a particular timezone
-// encoder.userInfo[DateTime.encodingTimeZoneKey] = TimeZone(identifier: "America/New_York")
+// encoder.userInfo[DateTime.timeZoneOverrideKey] = TimeZone(identifier: "America/New_York")
 
 // Encode using the specified timezone
 let jsonData = try encoder.encode(dateTime)

--- a/README.md
+++ b/README.md
@@ -105,6 +105,40 @@ contact.emailAddresses = [
 let person = Person(contact)
 ```
 
+### Configuring DateTime representations
+
+By default, `DateTime` objects are encoded with their specified time zone,
+or GMT/UTC if none is specified.
+You can override the time zone used during encoding by providing 
+a specific `TimeZone` in the `JSONEncoder`'s `userInfo` dictionary:
+
+```swift
+import Ontology
+
+// Create a DateTime object
+let dateTime = DateTime(Date())
+
+// Create an encoder that will use the local timezone
+let encoder = JSONEncoder()
+encoder.userInfo[DateTime.encodingTimeZoneKey] = TimeZone.current
+
+// Or specify a particular timezone
+// encoder.userInfo[DateTime.encodingTimeZoneKey] = TimeZone(identifier: "America/New_York")
+
+// Encode using the specified timezone
+let jsonData = try encoder.encode(dateTime)
+```
+
+This feature is particularly useful when:
+- Working with date-only values that should be interpreted in the user's local timezone
+- Ensuring consistent timezone representation across different data sources
+- Presenting dates to users in their local timezone regardless of how they were originally stored
+
+So to recap, the date encoding priority is:
+1. `TimeZone` from encoder's `userInfo` (if provided)
+2. `TimeZone` from the `DateTime` object (if specified)
+3. GMT/UTC (default fallback)
+
 ## Legal
 
 Apple Weather and Weather are trademarks of Apple Inc.

--- a/Sources/Ontology/Types/DateTime.swift
+++ b/Sources/Ontology/Types/DateTime.swift
@@ -25,7 +25,7 @@ extension DateTime: Codable {
     }
 
     /// UserInfo key for specifying a TimeZone to use when encoding DateTime values
-    public static let encodingTimeZoneKey = CodingUserInfoKey(
+    public static let timeZoneOverrideKey = CodingUserInfoKey(
         rawValue: "com.loopwork.Ontology.DateTimeEncodingTimeZone")!
 
     public init(from decoder: Decoder) throws {
@@ -63,7 +63,7 @@ extension DateTime: Codable {
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
         // Check if a TimeZone was provided in userInfo
-        if let userInfoTimeZone = encoder.userInfo[DateTime.encodingTimeZoneKey] as? TimeZone {
+        if let userInfoTimeZone = encoder.userInfo[DateTime.timeZoneOverrideKey] as? TimeZone {
             formatter.timeZone = userInfoTimeZone
         } else if let timeZone = timeZone {
             formatter.timeZone = timeZone

--- a/Sources/Ontology/Types/DateTime.swift
+++ b/Sources/Ontology/Types/DateTime.swift
@@ -24,7 +24,23 @@ extension DateTime: Codable {
         case timeZone
     }
 
-    /// UserInfo key for specifying a TimeZone to use when encoding DateTime values
+    /// A user info key that allows overriding the TimeZone used when encoding DateTime values.
+    ///
+    /// When encoding a DateTime, the TimeZone is determined in the following priority order:
+    /// 1. TimeZone from encoder.userInfo[DateTime.timeZoneOverrideKey] (if provided)
+    /// 2. TimeZone from the DateTime instance (if specified)
+    /// 3. GMT/UTC (default fallback)
+    ///
+    /// This is particularly useful for ensuring dates are interpreted correctly across different
+    /// time zones, or when you want to present all dates in a specific time zone regardless
+    /// of how they were originally stored.
+    ///
+    /// Example usage:
+    /// ```
+    /// let encoder = JSONEncoder()
+    /// encoder.userInfo[DateTime.timeZoneOverrideKey] = TimeZone.current
+    /// let encodedData = try encoder.encode(myDateTime)
+    /// ```
     public static let timeZoneOverrideKey = CodingUserInfoKey(
         rawValue: "com.loopwork.Ontology.DateTimeEncodingTimeZone")!
 

--- a/Tests/OntologyTests/DateTimeTests.swift
+++ b/Tests/OntologyTests/DateTimeTests.swift
@@ -111,7 +111,7 @@ struct DateTimeTests {
         // Create encoder with a different timezone in userInfo (New York)
         let encoder = JSONEncoder()
         let newYorkTimeZone = TimeZone(secondsFromGMT: -5 * 3600)!  // -05:00 (New York)
-        encoder.userInfo[DateTime.encodingTimeZoneKey] = newYorkTimeZone
+        encoder.userInfo[DateTime.timeZoneOverrideKey] = newYorkTimeZone
 
         // Encode the DateTime
         let encoded = try encoder.encode(dateTime)


### PR DESCRIPTION
Related to https://github.com/loopwork-ai/Ontology/pull/6
Related to https://github.com/loopwork-ai/iMCP/issues/44